### PR TITLE
lib: filter-ast: fix crash when an undefined filter is passed in

### DIFF
--- a/assets/js/lib/filter-ast.js
+++ b/assets/js/lib/filter-ast.js
@@ -18,7 +18,8 @@ export const isEqual = (needle, haystack) => {
     }
 }
 
-export const makeComparator = ({children, property, op, value}) => {
+export const makeComparator = (obj) => {
+    const {children, property, op, value} = obj || {}
     if (children == undefined) {
         if (property == undefined || op == undefined || value == undefined) {
             return () => true

--- a/assets/js/lib/filter-ast.test.js
+++ b/assets/js/lib/filter-ast.test.js
@@ -59,6 +59,9 @@ describe('makeComparator', () => {
             }
             expect(passed).toEqual(true)
         })
+        it('should always match with an undefined pattern', () => {
+            expect(makeComparator(undefined)(testObject)).toEqual(true)
+        })
         it('should always match without a property', () => {
             expect(makeComparator(pattern(undefined, 'is', 'Not A Name'))(testObject)).toEqual(true)
         })


### PR DESCRIPTION
Fixes: EBF-ORGANIZER-3J
Fixes: #92